### PR TITLE
Saas-ng additions

### DIFF
--- a/lib/minne/adapter.ex
+++ b/lib/minne/adapter.ex
@@ -8,7 +8,13 @@ defmodule Minne.Adapter do
   @callback default_opts() :: Keyword.t()
   @callback init(Upload.t(), opts) :: Upload.t()
   @callback start(Upload.t(), opts) :: Upload.t()
-  @callback write_part(Upload.t(), chunk :: binary(), size :: non_neg_integer(), opts) ::
-              Upload.t()
+  @callback write_part(
+              Upload.t(),
+              chunk :: binary(),
+              size :: non_neg_integer(),
+              final? :: boolean(),
+              opts
+            ) ::
+              Upload.t() | {:error, any()}
   @callback close(Upload.t(), opts) :: Upload.t()
 end

--- a/lib/minne/adapter/S3.ex
+++ b/lib/minne/adapter/S3.ex
@@ -1,22 +1,29 @@
 defmodule Minne.Adapter.S3 do
+  require Logger
   alias Minne.Upload
   @behaviour Minne.Adapter
 
-  @min_chunk 5_242_880
+  # compile time is fine because these are not env vars
+  @client Application.compile_env(:minne, :s3_client) || Minne.Clients.S3
+  @min_chunk Application.compile_env(:minne, :chunk_size) || 5_242_880
 
   @type t() :: %__MODULE__{
           key: String.t(),
           bucket: String.t(),
           parts: list(),
           parts_count: non_neg_integer(),
-          upload_id: String.t() | nil
+          upload_id: String.t() | nil,
+          hashes: map(),
+          max_file_size: non_neg_integer()
         }
 
   defstruct key: "",
             bucket: "",
             parts: [],
             parts_count: 0,
-            upload_id: nil
+            upload_id: nil,
+            hashes: %{},
+            max_file_size: 0
 
   @impl Minne.Adapter
   def default_opts() do
@@ -28,36 +35,101 @@ defmodule Minne.Adapter.S3 do
   def init(upload, opts) do
     %{
       upload
-      | adapter: %{upload.adapter | key: gen_key(opts), bucket: opts[:bucket]}
+      | adapter: %{
+          upload.adapter
+          | bucket: opts[:bucket],
+            max_file_size: opts[:max_file_size],
+            hashes: %{
+              sha256: :crypto.hash_init(:sha256),
+              sha1: :crypto.hash_init(:sha),
+              md5: :crypto.hash_init(:md5)
+            }
+        }
     }
   end
 
   @impl Minne.Adapter
   def start(upload, _opts) do
-    upload
+    adapter = %{upload.adapter | key: gen_timestamp_uuid_key(upload.request_url)}
+    %{upload | adapter: adapter}
   end
+
+  defp gen_timestamp_uuid_key(path) do
+    segments = String.split(path, "/", trim: true)
+
+    folder =
+      cond do
+        "upload" in segments ->
+          "bytes"
+
+        "kind" in segments ->
+          Enum.at(segments, 5)
+
+        "escalation" in segments ->
+          "escalation"
+
+        "files" in segments ->
+          "bytes"
+
+        true ->
+          error = "Invalid Kind provided when uploading to #{path}"
+          Logger.error(error)
+          raise RuntimeError, error
+      end
+
+    now = NaiveDateTime.utc_now()
+
+    folder <> "/#{now.year}/#{pad(now.month)}/#{pad(now.day)}/#{pad(now.hour)}/" <> UUID.uuid4()
+  end
+
+  defp pad(value) when value < 10, do: "0#{value}"
+  defp pad(value), do: Integer.to_string(value)
 
   @impl Minne.Adapter
   def write_part(
-        %{adapter: %__MODULE__{parts_count: parts_count}} = upload,
+        %Upload{adapter: %__MODULE__{parts_count: parts_count} = adapter} = upload,
         chunk,
         size,
+        _final?,
         _opts
       )
       when size < @min_chunk and parts_count == 0 do
-    ExAws.S3.put_object(upload.adapter.bucket, upload.adapter.key, chunk,
-      content_disposition: "attachment; filename=\"#{upload.filename}\""
-    )
-    |> ExAws.request!()
+    @client.put_object(upload.adapter.bucket, upload.adapter.key, chunk)
 
-    %{
-      upload
-      | size: size + upload.size
-    }
+    adapter = adapter |> update_hashes(chunk) |> finalize_hashes()
+
+    {:ok,
+     %{
+       upload
+       | size: size + upload.size,
+         adapter: adapter
+     }}
   end
 
-  def write_part(%{} = upload, chunk, size, _opts) do
-    upload |> set_upload_id() |> upload_part(size, chunk)
+  def write_part(
+        %Upload{adapter: %{max_file_size: max}} = upload,
+        chunk,
+        size,
+        final?,
+        _opts
+      ) do
+    if upload.size + size <= max do
+      IO.inspect("hit max")
+      upload = upload |> set_upload_id() |> upload_part(size, chunk, final?)
+      {:ok, upload}
+    else
+      abort_upload(upload)
+      {:error, "#{upload.request_url} only supports files smaller than (#{max / 1_048_576} MB)"}
+    end
+  end
+
+  # upload didnt start yet, nothing to abort
+  defp abort_upload(%{adapter: %{parts: []}}) do
+    %{}
+  end
+
+  defp abort_upload(%{adapter: %{bucket: bucket, key: key, upload_id: upload_id}}) do
+    @client.abort_multipart_upload(bucket, key, upload_id)
   end
 
   @impl Minne.Adapter
@@ -71,72 +143,152 @@ defmodule Minne.Adapter.S3 do
         } = upload,
         _opts
       ) do
-    reversed_parts = Enum.map(parts, &Task.await/1) |> Enum.reverse()
+    reversed_parts = Enum.map(parts, fn p -> Task.await(p, 10000) end) |> Enum.reverse()
 
-    ExAws.S3.complete_multipart_upload(
+    @client.complete_multipart_upload(
       bucket,
       key,
       upload_id,
       reversed_parts
     )
-    |> ExAws.request!()
 
     %{upload | adapter: %{adapter | parts: reversed_parts}}
   end
 
   defp set_upload_id(%{adapter: %{upload_id: nil, bucket: bucket, key: key} = adapter} = uploaded) do
     %{body: %{upload_id: upload_id}} =
-      ExAws.S3.initiate_multipart_upload(bucket, key,
-        content_disposition: "attachment; filename=\"#{uploaded.filename}\""
-      )
-      |> ExAws.request!()
+      @client.initiate_multipart_upload(bucket, key)
 
     %{uploaded | adapter: %{adapter | upload_id: upload_id}}
   end
 
   defp set_upload_id(%{adapter: %{upload_id: _upload_id}} = uploaded), do: uploaded
 
-  defp gen_key(opts) do
-    prefix = Keyword.get(opts, :upload_prefix, "upload")
-    key_generator = Keyword.get(opts, :key_generator, &default_key_generator/0)
+  # this represents the first chunk.
+  # since its always a jacked up size, we batch the first chunk with the second.
+  defp upload_part(%{chunk_size: 0} = uploaded, size, chunk, false) do
+    upload = %{
+      uploaded
+      | chunk_size: @min_chunk
+    }
 
-    Path.join([prefix, key_generator.()])
+    # this moves the chunk to the "remaining" flow to be picked up by the 2ed chunk and so on.
+    upload_part(upload, size, chunk, false)
   end
 
-  defp default_key_generator() do
-    :crypto.strong_rand_bytes(64) |> Base.url_encode64() |> binary_part(0, 32)
+  # all upload chunks need to be the same size, except the last chunk.
+  defp upload_part(
+         %{chunk_size: chunk_size, remainder_bytes: remainder, adapter: adapter} = uploaded,
+         size,
+         chunk,
+         false
+       ) do
+    chunk = remainder <> chunk
+
+    upload =
+      case extract_chunk(chunk, chunk_size) do
+        {<<>>, remaining} ->
+          %{
+            uploaded
+            | remainder_bytes: remaining
+          }
+
+        {chunk_to_process, remaining} ->
+          size = byte_size(chunk_to_process)
+          parts_count = uploaded.adapter.parts_count + 1
+
+          new_part_async = upload_async(uploaded, parts_count, chunk_to_process)
+          adapter = adapter |> update_hashes(chunk_to_process)
+
+          %{
+            uploaded
+            | size: size + uploaded.size,
+              remainder_bytes: remaining,
+              adapter: %{
+                adapter
+                | parts_count: parts_count,
+                  parts: [new_part_async | uploaded.adapter.parts]
+              }
+          }
+
+          # ensure no more then 1 chunk worth of data is left in remaining
+      end
+
+    if byte_size(upload.remainder_bytes) >= chunk_size do
+      upload_part(upload, size, "", false)
+    else
+      upload
+    end
   end
 
-  defp upload_part(%{} = uploaded, size, body) do
+  # ensure final remaining bytes are uploaded
+  defp upload_part(
+         %{adapter: adapter} = uploaded,
+         _size,
+         remaining_bytes,
+         true
+       ) do
+    size = byte_size(remaining_bytes)
     parts_count = uploaded.adapter.parts_count + 1
 
-    new_part_async = upload_async(uploaded, parts_count, body)
+    new_part_async = upload_async(uploaded, parts_count, remaining_bytes)
+    adapter = adapter |> update_hashes(remaining_bytes) |> finalize_hashes()
 
     %{
       uploaded
       | size: size + uploaded.size,
+        remainder_bytes: "",
         adapter: %{
-          uploaded.adapter
+          adapter
           | parts_count: parts_count,
             parts: [new_part_async | uploaded.adapter.parts]
         }
     }
   end
 
+  defp extract_chunk(data, size) do
+    if byte_size(data) >= size do
+      <<chunk::binary-size(size), remainder::binary>> = data
+      {chunk, remainder}
+    else
+      # Not enough data to form a full chunk yet
+      {<<>>, data}
+    end
+  end
+
   # launches async task to upload this part.
-  defp upload_async(uploaded, parts_count, body) do
+  defp upload_async(uploaded, parts_count, chunk) do
     Task.async(fn ->
       %{headers: headers} =
-        ExAws.S3.upload_part(
+        @client.upload_part(
           uploaded.adapter.bucket,
           uploaded.adapter.key,
           uploaded.adapter.upload_id,
           parts_count,
-          body
+          chunk
         )
-        |> ExAws.request!()
 
       {parts_count, Minne.get_header(headers, "ETag")}
     end)
+  end
+
+  defp update_hashes(%{hashes: %{sha256: sha256, md5: md5, sha1: sha}} = adapter, chunk) do
+    hashes = %{
+      sha256: :crypto.hash_update(sha256, chunk),
+      sha1: :crypto.hash_update(sha, chunk),
+      md5: :crypto.hash_update(md5, chunk)
+    }
+
+    %{adapter | hashes: hashes}
+  end
+
+  defp finalize_hashes(%{hashes: %{sha256: sha256, md5: md5, sha1: sha}} = adapter) do
+    hashes = %{
+      sha256: :crypto.hash_final(sha256) |> Base.encode16(case: :lower),
+      sha1: :crypto.hash_final(sha) |> Base.encode16(case: :lower),
+      md5: :crypto.hash_final(md5) |> Base.encode16(case: :lower)
+    }
+
+    %{adapter | hashes: hashes}
   end
 end

--- a/lib/minne/adapter/temp.ex
+++ b/lib/minne/adapter/temp.ex
@@ -29,7 +29,7 @@ defmodule Minne.Adapter.Temp do
   end
 
   @impl Minne.Adapter
-  def write_part(upload, chunk, size, _opts) do
+  def write_part(upload, chunk, size, _, _opts) do
     binwrite!(upload.adapter.file, chunk)
 
     %{upload | size: upload.size + size}

--- a/lib/minne/s3/client_behavior.ex
+++ b/lib/minne/s3/client_behavior.ex
@@ -1,0 +1,36 @@
+defmodule Minne.Clients.S3Behaviour do
+  @moduledoc """
+  Behaviour for the CloudflareClient to support mocking in tests.
+  """
+  @callback put_object(
+              bucket :: binary(),
+              key :: binary(),
+              body :: binary()
+            ) :: map()
+
+  @callback complete_multipart_upload(
+              bucket :: binary(),
+              key :: binary(),
+              upload_id :: binary(),
+              parts :: list()
+            ) :: map()
+
+  @callback initiate_multipart_upload(
+              bucket :: binary(),
+              key :: binary()
+            ) :: map()
+
+  @callback upload_part(
+              bucket :: binary(),
+              key :: binary(),
+              upload_id :: binary(),
+              part_number :: integer(),
+              chunk :: binary()
+            ) :: map()
+
+  @callback abort_multipart_upload(
+              bucket :: binary(),
+              key :: binary(),
+              upload_id :: binary()
+            ) :: map()
+end

--- a/lib/minne/s3/s3_client.ex
+++ b/lib/minne/s3/s3_client.ex
@@ -1,0 +1,64 @@
+defmodule Minne.Clients.S3 do
+  @moduledoc """
+  Implements the s3 client behavior
+  """
+
+  @behaviour Minne.Clients.S3Behaviour
+  def put_object(
+        bucket,
+        key,
+        body
+      ) do
+    ExAws.S3.put_object(bucket, key, body)
+    |> ExAws.request!()
+  end
+
+  def complete_multipart_upload(
+        bucket,
+        key,
+        upload_id,
+        parts
+      ) do
+    ExAws.S3.complete_multipart_upload(
+      bucket,
+      key,
+      upload_id,
+      parts
+    )
+    |> ExAws.request!()
+  end
+
+  def initiate_multipart_upload(
+        bucket,
+        key
+      ) do
+    ExAws.S3.initiate_multipart_upload(bucket, key)
+    |> ExAws.request!()
+  end
+
+  def upload_part(
+        bucket,
+        key,
+        upload_id,
+        part_number,
+        chunk
+      ) do
+    ExAws.S3.upload_part(
+      bucket,
+      key,
+      upload_id,
+      part_number,
+      chunk
+    )
+    |> ExAws.request!()
+  end
+
+  def abort_multipart_upload(
+        bucket,
+        key,
+        upload_id
+      ) do
+    ExAws.S3.abort_multipart_upload(bucket, key, upload_id)
+    |> ExAws.request!()
+  end
+end

--- a/lib/minne/upload.ex
+++ b/lib/minne/upload.ex
@@ -10,13 +10,19 @@ defmodule Minne.Upload do
           filename: String.t(),
           content_type: String.t(),
           size: non_neg_integer(),
-          adapter: map() | atom() | nil
+          adapter: map() | atom() | nil,
+          chunk_size: non_neg_integer(),
+          remainder_bytes: binary() | nil,
+          request_url: String.t()
         }
 
   defstruct filename: "",
             content_type: "",
             size: 0,
-            adapter: nil
+            adapter: nil,
+            chunk_size: 0,
+            remainder_bytes: "",
+            request_url: ""
 
   def new(adapter) do
     %__MODULE__{adapter: adapter}


### PR DESCRIPTION
the repo has a good idea/initial implementation behind it and works great so long as the file doesn't use the multipart flow.
maybe sending non-uniform chunk sizes works for aws, but for r2 its a big no-no.

so the main changes between mine and what he has are:
- custom logic for generating the r2 key.
- implemented s3 client & made it mockable.
- if the first chunk is not the last chunk and is smaller then our desired chunk size, its carried over to the next pass. (w/ final processing)
- hashes are generated during upload.
- max_file_size is validated and aborted if needed during upload.